### PR TITLE
Potential fix for code scanning alert no. 2: Arbitrary file access during archive extraction ("Zip Slip")

### DIFF
--- a/util/src/main/java/io/kubernetes/client/Copy.java
+++ b/util/src/main/java/io/kubernetes/client/Copy.java
@@ -193,6 +193,12 @@ public class Copy extends Exec {
           throw new IOException("Invalid entry: " + entry.getName());
         }
         File f = new File(destination.toFile(), normalName);
+        // Zip Slip protection: verify that output path is inside destination
+        Path destDirPath = destination.toAbsolutePath().normalize();
+        Path filePath = f.toPath().toAbsolutePath().normalize();
+        if (!filePath.startsWith(destDirPath)) {
+          throw new IOException("Entry is outside of the target dir: " + entry.getName());
+        }
         if (entry.isDirectory()) {
           if (!f.isDirectory() && !f.mkdirs()) {
             throw new IOException("create directory failed: " + f);


### PR DESCRIPTION
Potential fix for [https://github.com/010secureng/java/security/code-scanning/2](https://github.com/010secureng/java/security/code-scanning/2)

The best way to fix this vulnerability is to ensure that, after constructing the full output path for the file to be extracted (using the archive entry name combined with the destination directory), we check that the resulting path is still contained within the intended extraction root. The most reliable method is to use `Path` objects and perform normalization, then check that the normalized output path starts with the normalized destination root using `Path.startsWith(..)`. Specifically, after creating `File f = new File(destination.toFile(), normalName);`, you should do:

```java
Path destDirPath = destination.toAbsolutePath().normalize();
Path filePath = f.toPath().toAbsolutePath().normalize();
if (!filePath.startsWith(destDirPath)) {
    throw new IOException("Entry is outside of the target dir: " + entry.getName());
}
```

This check should be added after line 195, before any file or directory operations (including creation). The imports are already present (`java.nio.file.Path`), so no new imports are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
